### PR TITLE
fix compiler error with g++ and set up gdextension for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Linux object files
+*.os

--- a/.gitignore
+++ b/.gitignore
@@ -402,4 +402,4 @@ FodyWeavers.xsd
 *.sln.iml
 
 # Linux object files
-*.os
+*.so

--- a/SConstruct
+++ b/SConstruct
@@ -4,7 +4,6 @@ import sys
 
 from methods import print_error
 
-
 libname = "OptiTrack-plugin"
 projectdir = "example-project"
 
@@ -33,7 +32,10 @@ env = SConscript("godot-cpp/SConstruct", {"env": env, "customs": customs})
 env.Append(CPPPATH=["src/", "include/"])
 sources = Glob("src/*.cpp")
 
-env.Append(LIBS=["NatNetLib"])
+if env["platform"] in ("linuxbsd", "linux"):
+    env.Append(LIBS=["libNatNet"])
+else:
+    env.Append(LIBS=["NatNetLib"])
 env.Append(LIBPATH=["lib/NatNet/"])
 
 if env["target"] in ["editor", "template_debug"]:

--- a/example-project/addons/optitrack_plugin/optitrack-plugin.gdextension
+++ b/example-project/addons/optitrack_plugin/optitrack-plugin.gdextension
@@ -64,3 +64,8 @@ windows.x86_64.single.debug = "./bin/NatNetLib.dll"
 windows.x86_64.double.debug = "./bin/NatNetLib.dll"
 windows.x86_64.single.release = "./bin/NatNetLib.dll"
 windows.x86_64.double.release = "./bin/NatNetLib.dll"
+
+linux.x86_64.single.debug = "./bin/libNatNet.so"
+linux.x86_64.double.debug = "./bin/libNatNet.so"
+linux.x86_64.single.release = "./bin/libNatNet.so"
+linux.x86_64.double.release = "./bin/libNatNet.so"

--- a/src/motive_client.h
+++ b/src/motive_client.h
@@ -13,6 +13,8 @@
 
 using namespace godot;
 
+void NATNET_CALLCONV DataHandler(sFrameOfMocapData* data, void* pUserData);
+
 class MotiveClient : public Node {
 	GDCLASS(MotiveClient, Node)
 


### PR DESCRIPTION
Hello! I saw your extension this week, and was so excited that I had to try it out today in an Optitrack mocap space at my university. It was exciting how simple it was to get working, and you fixed a bug right before I reported it to ya'll. Thank you for supporting the Godot ecosystem!

I would like to get the extension working in a Linux environment so I can develop with it more easily. Even if you choose to not provide official Linux support, these changes reduce friction for other developers looking to use this plugin in the future. Not seeing any contributor guidelines, but here are a list of my changes:

- `g++` was unable to find the DataHandler method due to how it was ordered, so I simply placed the function signature at the top of the header file (since it's required for the `MotiveClient` constructor).

- There are [NatNetSDK binaries](https://optitrack.com/support/downloads?cat=developer-tools) for Ubuntu and Fedora. I'm not sure if they're the exact same, and assumed you would be in more official capacity to include them, so I did not upload them with this PR, but they're probably worth documenting somewhere. I simply placed the `libNatNet.so` into both the `lib/NatNet/` and `example-project/addons/optitrack_plugin/bin/` directories. I also added the associated dependency in the `.gdextension` file.

- I modified the SConstruct to include these binaries based on the target platform (which is inherited from the `godot-cpp` scons environment). If you are interested in some former art, I referenced the `gdextension` branch of [Godot Steam](https://codeberg.org/godotsteam/godotsteam/src/branch/gdextension/SConstruct) since they are dealing with Steam SDK binaries for multiple platforms in a cross-compiled context. It's not perfect, but it gets the job done.


Finally, I noticed that your `compatibility_minimum` in the `.gdextension` file is set to Godot 4.1, but it seems like you're compiling either `godot-cpp` 4.4 or 4.5. If I remember correctly, gdextensions compiled on older versions of Godot are forwards compatible, but I don't believe gdextensions compiled for newer versions are backwards-compatible (I could be wrong though). Would probably want to double-check this.

Let me know if anything needs changing. Thank you for your time and hard work!